### PR TITLE
If SimOperatorName is empty get NetworkOperatorName

### DIFF
--- a/src/android/com/dtmtec/Carrier.java
+++ b/src/android/com/dtmtec/Carrier.java
@@ -20,6 +20,9 @@ public class Carrier extends CordovaPlugin {
       TelephonyManager manager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
 
       String carrierName = manager.getSimOperatorName(); // VIVO
+      if("".equals(carrierName)){
+        carrierName = manager.getNetworkOperatorName();
+      }
       String simOperator = manager.getSimOperator(); // 72411
 
       String mcc = simOperator.substring(0, Math.min(simOperator.length(), 3)); // 724


### PR DESCRIPTION
Some carrier in my case "TURKCELL" returns to CarrierName as "" so i try to get it from NetworkOperatorName
Example code is given http://stackoverflow.com/questions/3838602/how-to-find-out-carriers-name-in-android
